### PR TITLE
Slight update to surge deployment instructions

### DIFF
--- a/docs/tutorial/part-one/index.md
+++ b/docs/tutorial/part-one/index.md
@@ -345,7 +345,7 @@ If you haven't previously installed &amp; set up Surge, open a new terminal wind
 npm install --global surge
 
 # Then create a (free) account with them
-surge
+surge login
 ```
 
 Next, build your site by running the following command in the terminal at the root of your site (tip: make sure you're running this command at the root of your site, in this case in the hello-world folder, which you can do by opening a new tab in the same window you used to run `gatsby develop`):


### PR DESCRIPTION
Updated to specify 'surge login` instead of just `surge` after installing the Surge CLI via npm. Using `surge login` just lets the user create the account, while the latter creates the account and then proceeds with deployment prompts, but at this point in the tutorial user is not ready to deploy since `gatsby build` has not been run .

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

<!--
  Is this a blog post? Check out the docs at https://www.gatsbyjs.org/contributing/blog-and-website-contributions/, and please mention if the blog post is pre-approved
  by someone from Gatsby.
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
